### PR TITLE
Refresh stale Nvidia access token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ slack_config.json
 geckodriver.log
 .profile
 *.log
+__pycache__/
+*.py[cod]

--- a/stores/nvidia.py
+++ b/stores/nvidia.py
@@ -225,7 +225,7 @@ class NvidiaBuyer:
         log.info("Adding driver cookies to session")
 
         log.info("Getting product IDs")
-        self.access_token = self.get_nividia_access_token()
+        self.token_data = self.get_nvidia_access_token()
         self.payment_option = self.get_payment_options()
         if not self.payment_option.get("id") or not self.cvv:
             log.error("No payment option on account or missing CVV. Disable Autobuy")
@@ -245,6 +245,13 @@ class NvidiaBuyer:
             )
             self.get_product_ids()
             sleep(5)
+
+    @property
+    def access_token(self):
+        if datetime.today().timestamp() >= self.token_data.get('expires_at'):
+            log.debug('Access token expired')
+            self.token_data = self.get_nvidia_access_token()
+        return self.token_data['access_token']
 
     def has_valid_creds(self):
         if all(item in self.config.keys() for item in AUTOBUY_CONFIG_KEYS):
@@ -266,6 +273,7 @@ class NvidiaBuyer:
             "expand": "product",
             "fields": "product.id,product.displayName,product.pricing",
             "locale": self.locale,
+            "format": "json"
         }
         headers = DEFAULT_HEADERS.copy()
         headers["locale"] = self.locale
@@ -510,21 +518,24 @@ class NvidiaBuyer:
             return self.cli_locale[3:].upper() in response_json["product"]["name"]
         return True
 
-    def get_nividia_access_token(self):
+    def get_nvidia_access_token(self):
         log.debug("Getting session token")
+        now = datetime.today()
         payload = {
             "apiKey": DIGITAL_RIVER_API_KEY,
             "format": "json",
             "locale": self.locale,
             "currency": "USD",
-            "_": datetime.today(),
+            "_": now,
         }
         response = self.session.get(
             NVIDIA_TOKEN_URL, headers=DEFAULT_HEADERS, params=payload
         )
         log.debug(response.status_code)
-        log.debug(f"Nvidia access token: {response.json()['access_token']}")
-        return response.json()["access_token"]
+        data = response.json()
+        log.debug(f"Nvidia access token: {data['access_token']}")
+        data['expires_at'] = round(now.timestamp() + data['expires_in']) - 60
+        return data
 
     def is_signed_in(self):
         try:


### PR DESCRIPTION
- Added a simple wrapper on the `access_token` property that checks for token freshness and grabs a new token before the current token expires (should allow for runs lasting longer than 24 hours)

- _Minor_: added explicit `format: json` param in `get_product_ids` request payload. Responses were being implicitly cast to JSON via the `Accept` option in `DEFAULT_HEADERS`

Partially resolves #55 