### PR TITLE
Suppressing the bluetooth message in bot's nvidia store

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -7,6 +7,7 @@ from stores.amazon import Amazon
 from stores.bestbuy import BestBuyHandler
 from stores.evga import Evga
 from stores.nvidia import NvidiaBuyer, GPU_DISPLAY_NAMES, ACCEPTED_LOCALES
+from utils import selenium_utils
 
 
 @click.group()
@@ -61,11 +62,15 @@ def nvidia(gpu, locale):
     default=lambda: int(os.environ.get("amazon_price_limit", 1000)),
     show_default="current user",
 )
-def amazon(amazon_email, amazon_password, amazon_item_url, amazon_price_limit):
+@click.option("--no-image", is_flag=True)
+def amazon(amazon_email, amazon_password, amazon_item_url, amazon_price_limit, no_image):
     os.environ.setdefault("amazon_email", amazon_email)
     os.environ.setdefault("amazon_password", amazon_password)
     os.environ.setdefault("amazon_item_url", amazon_item_url)
     os.environ.setdefault("amazon_price_limit", str(amazon_price_limit))
+	
+    if(no_image):
+	    selenium_utils.no_amazon_image()
 
     amzn_obj = Amazon(username=amazon_email, password=amazon_password, debug=True)
     amzn_obj.run_item(item_url=amazon_item_url, price_limit=amazon_price_limit)

--- a/stores/nvidia.py
+++ b/stores/nvidia.py
@@ -244,8 +244,6 @@ class NvidiaBuyer:
         self.notification_handler = NotificationHandler()
 
         log.info("Opening Webdriver")
-        chrome_options = webdriver.ChromeOptions()
-        chrome_options.add_experimental_option("excludeSwitches", ["enable-logging"])
         self.driver = webdriver.Chrome(
             executable_path=binary_path, options=options, chrome_options=chrome_options
         )

--- a/stores/nvidia.py
+++ b/stores/nvidia.py
@@ -244,6 +244,8 @@ class NvidiaBuyer:
         self.notification_handler = NotificationHandler()
 
         log.info("Opening Webdriver")
+        chrome_options = webdriver.ChromeOptions()
+        chrome_options.add_experimental_option("excludeSwitches", ["enable-logging"])
         self.driver = webdriver.Chrome(
             executable_path=binary_path, options=options, chrome_options=chrome_options
         )

--- a/utils/selenium_utils.py
+++ b/utils/selenium_utils.py
@@ -15,8 +15,9 @@ chrome_options.add_experimental_option("useAutomationExtension", False)
 options.add_experimental_option("excludeSwitches", ["enable-automation"])
 options.add_experimental_option("useAutomationExtension", False)
 
-# prefs = {"profile.managed_default_content_settings.images": 2}
-# chrome_options.add_experimental_option("prefs", prefs)
+def no_amazon_image():
+    prefs = {"profile.managed_default_content_settings.images": 2}
+    chrome_options.add_experimental_option("prefs", prefs)
 
 
 def wait_for_element(d, e_id, time=30):


### PR DESCRIPTION
Suppresses the error message similar to 
`ERROR:device_event_log_impl.cc(162)] [15:29:54.314] Bluetooth: bluetooth_adapter_winrt.cc:1055 Getting Default Adapter failed.`