### PR TITLE
Fixed error that occurred when there's a sale on Amazon.

### DIFF
--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -70,7 +70,10 @@ class Amazon:
                 log.warn("A polling request timed out. Retrying.")
 
         log.info("Item in stock, buy now button found!")
-        price_str = self.driver.find_element_by_id("priceblock_ourprice").text
+        try:
+            price_str = self.driver.find_element_by_id("priceblock_ourprice").text
+        except:
+            price_str = self.driver.find_element_by_id("priceblock_dealprice").text
         price_int = int(round(float(price_str.strip("$"))))
         if price_int < price_limit:
             log.info(f"Attempting to buy item for {price_int}")

--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -7,6 +7,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.expected_conditions import presence_of_element_located
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import NoSuchElementException
 
 from notifications.notifications import NotificationHandler
 from utils.logger import log
@@ -72,7 +73,7 @@ class Amazon:
         log.info("Item in stock, buy now button found!")
         try:
             price_str = self.driver.find_element_by_id("priceblock_ourprice").text
-        except:
+        except NoSuchElementException as _:
             price_str = self.driver.find_element_by_id("priceblock_dealprice").text
         price_int = int(round(float(price_str.strip("$"))))
         if price_int < price_limit:


### PR DESCRIPTION
When there is a sale going on, Amazon changes the ID name from "priceblock_ourprice" to "priceblock_dealprice" instead. I've added a try/catch to fix this. Not sure if this is the right way to go about fixing this, let me know if there is a better way.