### PR TITLE
Persist Amazon login across sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ autobuy_config.json
 slack_config.json
 geckodriver.log
 .profile
+.profile-amz
 *.log
 __pycache__/
 *.py[cod]

--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -30,14 +30,14 @@ class Amazon:
         self.password = password
         self.driver.get(BASE_URL)
         if self.is_logged_in():
-            log.info('Already logged in')
+            log.info("Already logged in")
         else:
             self.login()
         time.sleep(3)
 
     def is_logged_in(self):
         try:
-            text = wait_for_element(self.driver, 'nav-link-accountList').text
+            text = wait_for_element(self.driver, "nav-link-accountList").text
             return "Hello, Sign in" not in text
         except Exception:
             return False

--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -11,8 +11,11 @@ from selenium.common.exceptions import NoSuchElementException
 
 from notifications.notifications import NotificationHandler
 from utils.logger import log
-from utils.selenium_utils import options, enable_headless
+from utils.selenium_utils import options, enable_headless, wait_for_element
 
+options.add_argument("user-data-dir=.profile-amz")
+
+BASE_URL = "https://www.amazon.com/"
 LOGIN_URL = "https://www.amazon.com/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fwww.amazon.com%2F%3Fref_%3Dnav_custrec_signin&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=usflex&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&"
 
 
@@ -25,8 +28,19 @@ class Amazon:
         self.wait = WebDriverWait(self.driver, 10)
         self.username = username
         self.password = password
-        self.login()
+        self.driver.get(BASE_URL)
+        if self.is_logged_in():
+            log.info('Already logged in')
+        else:
+            self.login()
         time.sleep(3)
+
+    def is_logged_in(self):
+        try:
+            text = wait_for_element(self.driver, 'nav-link-accountList').text
+            return "Hello, Sign in" not in text
+        except Exception:
+            return False
 
     def login(self):
         self.driver.get(LOGIN_URL)

--- a/stores/nvidia.py
+++ b/stores/nvidia.py
@@ -254,8 +254,10 @@ class NvidiaBuyer:
             if self.enabled:
                 log.info(f"{self.gpu_long_name} is in stock. Go buy it.")
                 cart_url = self.open_cart_url(product_id)
-                self.notification_handler.send_notification(f" {self.gpu_long_name} with product ID: {product_id} in "
-                                                            f"stock: {cart_url}")
+                self.notification_handler.send_notification(
+                    f" {self.gpu_long_name} with product ID: {product_id} in "
+                    f"stock: {cart_url}"
+                )
                 self.enabled = False
         except Timeout:
             log.error("Had a timeout error.")


### PR DESCRIPTION
Uses `user-data-dir` chromedriver option and checks if we are already logged in before calling `login()` 

Should help with #94 