### PR TITLE
Add Join as a notification option

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,18 @@ store the url from the pavlok app in the ```pavlok_config.json``` file, you can 
 }
 ```
 
+#### Join
+To enable Join notifications, make a copy of the `join_config.template_json` file and name it `join_config.json`  
+Go [here](https://joinjoaomgcd.appspot.com/) and select the device you want to notify.  
+Click the `JOIN API` tab and paste the value next to `Device Id` into your `join_config.json` `deviceId` section.  
+Next click the `SHOW` button next to `API Key` and copy that value into your `join_config.json` `apikey` section.
+```
+{
+  "apikey": "paste api key here",
+  "deviceId": "paste device id here"
+}
+```
+
 
 
 ## Troubleshooting

--- a/join_config.template_json
+++ b/join_config.template_json
@@ -1,5 +1,4 @@
 {
-  "base_url": "https://joinjoaomgcd.appspot.com/_ah/api/messaging/v1/sendPush",
-  "apikey": "get api key here: https://joinjoaomgcd.appspot.com/",
-  "deviceId": "find device id here: https://joinjoaomgcd.appspot.com/_ah/api/registration/v1/listDevices?apikey={apikey}"
+  "apikey": "paste api key here",
+  "deviceId": "paste device id here"
 }

--- a/join_config.template_json
+++ b/join_config.template_json
@@ -1,0 +1,5 @@
+{
+  "base_url": "https://joinjoaomgcd.appspot.com/_ah/api/messaging/v1/sendPush",
+  "apikey": "get api key here: https://joinjoaomgcd.appspot.com/",
+  "deviceId": "find device id here: https://joinjoaomgcd.appspot.com/_ah/api/registration/v1/listDevices?apikey={apikey}"
+}

--- a/notifications/notifications.py
+++ b/notifications/notifications.py
@@ -51,7 +51,7 @@ class NotificationHandler:
             if self.discord_handler.enabled:
                 executor.submit(self.discord_handler.send, message)
             if self.join_handler.enabled:
-                self.join_handler.send(message)
+                executor.submit(self.join_handler.send, message)
             if self.telegram_handler.enabled:
                 executor.submit(self.telegram_handler.send, message)
             if self.slack_handler.enabled:

--- a/notifications/notifications.py
+++ b/notifications/notifications.py
@@ -51,7 +51,7 @@ class NotificationHandler:
             if self.discord_handler.enabled:
                 executor.submit(self.discord_handler.send, message)
             if self.join_handler.enabled:
-            self.join_handler.send(message)
+                self.join_handler.send(message)
             if self.telegram_handler.enabled:
                 executor.submit(self.telegram_handler.send, message)
             if self.slack_handler.enabled:

--- a/notifications/notifications.py
+++ b/notifications/notifications.py
@@ -2,6 +2,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from notifications.providers.audio import AudioHandler
 from notifications.providers.discord import DiscordHandler
+from notifications.providers.join import JoinHandler
 from notifications.providers.pavlok import PavlokHandler
 from notifications.providers.slack import SlackHandler
 from notifications.providers.telegram import TelegramHandler
@@ -15,6 +16,7 @@ class NotificationHandler:
         self.audio_handler = AudioHandler()
         self.twilio_handler = TwilioHandler()
         self.discord_handler = DiscordHandler()
+        self.join_handler = JoinHandler()
         self.telegram_handler = TelegramHandler()
         self.slack_handler = SlackHandler()
         self.pavlok_handler = PavlokHandler()
@@ -28,6 +30,8 @@ class NotificationHandler:
             enabled_handlers.append("Twilio")
         if self.discord_handler.enabled:
             enabled_handlers.append("Discord")
+        if self.join_handler.enabled:
+            enabled_handlers.append("Join")
         if self.telegram_handler.enabled:
             enabled_handlers.append("Telegram")
         if self.slack_handler.enabled:
@@ -46,6 +50,8 @@ class NotificationHandler:
                 executor.submit(self.twilio_handler.send, message)
             if self.discord_handler.enabled:
                 executor.submit(self.discord_handler.send, message)
+            if self.join_handler.enabled:
+            self.join_handler.send(message)
             if self.telegram_handler.enabled:
                 executor.submit(self.telegram_handler.send, message)
             if self.slack_handler.enabled:

--- a/notifications/providers/join.py
+++ b/notifications/providers/join.py
@@ -41,7 +41,10 @@ class JoinHandler:
                 message_body = self.url_re.sub("", message_body).strip()
                 payload.update({"text": message_body, "url": url.group(0)})
 
-            response = requests.get("https://joinjoaomgcd.appspot.com/_ah/api/messaging/v1/sendPush", params=payload)
+            response = requests.get(
+                "https://joinjoaomgcd.appspot.com/_ah/api/messaging/v1/sendPush",
+                params=payload,
+            )
             log.info(f"Join notification status: {response.status_code}")
         except Exception as e:
             log.error(e)

--- a/notifications/providers/join.py
+++ b/notifications/providers/join.py
@@ -35,8 +35,8 @@ class JoinHandler:
 
             if url:
                 message_body = self.url_re.sub('', message_body).strip()
-                payload.update({"text": message_body, "url": url})
-                
+                payload.update({"text": message_body, "url": url.group(0)})
+
             response = requests.get(self.base_url, params=payload)
             log.info(f"Join notification status: {response.status_code}")
         except Exception as e:

--- a/notifications/providers/join.py
+++ b/notifications/providers/join.py
@@ -7,7 +7,7 @@ import re
 from utils.logger import log
 
 JOIN_CONFIG_PATH = "join_config.json"
-JOIN_CONFIG_KEYS = ["base_url", "deviceId", "apikey"]
+JOIN_CONFIG_KEYS = ["deviceId", "apikey"]
 
 
 class JoinHandler:
@@ -20,8 +20,7 @@ class JoinHandler:
         if path.exists(JOIN_CONFIG_PATH):
             with open(JOIN_CONFIG_PATH) as json_file:
                 self.config = json.load(json_file)
-                if self.config["base_url"]:
-                    self.base_url = self.config["base_url"]
+                if self.config["deviceId"]:
                     self.deviceId = self.config["deviceId"]
                     self.apikey = self.config["apikey"]
                     self.enabled = True
@@ -42,7 +41,7 @@ class JoinHandler:
                 message_body = self.url_re.sub("", message_body).strip()
                 payload.update({"text": message_body, "url": url.group(0)})
 
-            response = requests.get(self.base_url, params=payload)
+            response = requests.get("https://joinjoaomgcd.appspot.com/_ah/api/messaging/v1/sendPush", params=payload)
             log.info(f"Join notification status: {response.status_code}")
         except Exception as e:
             log.error(e)

--- a/notifications/providers/join.py
+++ b/notifications/providers/join.py
@@ -7,12 +7,12 @@ import re
 from utils.logger import log
 
 JOIN_CONFIG_PATH = "join_config.json"
-JOIN_CONFIG_KEYS = ["base_url","deviceId","apikey"]
+JOIN_CONFIG_KEYS = ["base_url", "deviceId", "apikey"]
 
 
 class JoinHandler:
     enabled = False
-    url_re = re.compile(r'https[^ ]+')
+    url_re = re.compile(r"https[^ ]+")
 
     def __init__(self):
         log.debug("Initializing join handler")
@@ -31,10 +31,15 @@ class JoinHandler:
     def send(self, message_body):
         try:
             url = self.url_re.search(message_body)
-            payload = { "text": message_body, "title": "Nvidia-Bot Alert", "deviceId": self.deviceId, "apikey": self.apikey}
+            payload = {
+                "text": message_body,
+                "title": "Nvidia-Bot Alert",
+                "deviceId": self.deviceId,
+                "apikey": self.apikey,
+            }
 
             if url:
-                message_body = self.url_re.sub('', message_body).strip()
+                message_body = self.url_re.sub("", message_body).strip()
                 payload.update({"text": message_body, "url": url.group(0)})
 
             response = requests.get(self.base_url, params=payload)

--- a/notifications/providers/join.py
+++ b/notifications/providers/join.py
@@ -1,0 +1,45 @@
+import json
+from os import path
+
+import requests
+import re
+
+from utils.logger import log
+
+JOIN_CONFIG_PATH = "join_config.json"
+JOIN_CONFIG_KEYS = ["base_url","deviceId","apikey"]
+
+
+class JoinHandler:
+    enabled = False
+    url_re = re.compile(r'https[^ ]+')
+
+    def __init__(self):
+        log.debug("Initializing join handler")
+
+        if path.exists(JOIN_CONFIG_PATH):
+            with open(JOIN_CONFIG_PATH) as json_file:
+                self.config = json.load(json_file)
+                if self.config["base_url"]:
+                    self.base_url = self.config["base_url"]
+                    self.deviceId = self.config["deviceId"]
+                    self.apikey = self.config["apikey"]
+                    self.enabled = True
+        else:
+            log.debug("No join config found.")
+
+    def send(self, message_body):
+        try:
+            url = self.url_re.search(message_body)
+            payload = { "text": message_body, "title": "Nvidia-Bot Alert", "deviceId": self.deviceId, "apikey": self.apikey}
+
+            if url:
+                message_body = self.url_re.sub('', message_body).strip()
+                payload.update({"text": message_body, "url": url})
+                
+            response = requests.get(self.base_url, params=payload)
+            log.info(f"Join notification status: {response.status_code}")
+        except Exception as e:
+            log.error(e)
+            log.warn("Join notification failed")
+            self.enabled = False


### PR DESCRIPTION
Join can push notifications to android devices.

When making this I had to parse out the url from the message sent to notifications due to how join works.
I'm questioning though if it even makes sense to send the url in a notification though.  It's a one time use url right?  And it's immediately being used on the local machine.  I tried opening the url on my phone and it didn't work.  Maybe I'm just misunderstanding what's required for the nvidia shopping cart url.