### PR TITLE
Manual Checkout Links

### DIFF
--- a/keylinks.md
+++ b/keylinks.md
@@ -1,0 +1,15 @@
+Key links for Manual Checkout
+(Created for Sharing on the Discord)
+
+Zotac Store (link step by step):
+http://store.zotac.com/customer/account/login/ 
+https://store.zotac.com/checkout/cart/add/uenc/[insert cart code] 
+https://store.zotac.com/paypal/express/start/  
+https://store.zotac.com/paypal/express/review/
+
+EVGA Store:
+[add to cart link, check out]
+https://secure.evga.com/US/login.asp
+https://secure.evga.com/Cart/Checkout_Shipping.aspx
+https://secure.evga.com/Cart/Checkout_Payment.aspx
+https://secure.evga.com/Cart/Checkout_PlaceOrder.aspx


### PR DESCRIPTION
Thought we should document a list of key links that we can link for folks on discord trying to do manual checkouts on drops - as it's almost impossible to check-out on non-responsive websites without the links due as you can get into a timeout loop. And there's lot of Discord questions everytime this happens. 