### PR TITLE
Add support for Amazon.ca

### DIFF
--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -34,7 +34,7 @@ HOME_PAGE_TITLES = [
     "Amazon.de: Günstige Preise für Elektronik & Foto, Filme, Musik, Bücher, Games, Spielzeug & mehr",
     "Amazon.es: compra online de electrónica, libros, deporte, hogar, moda y mucho más.",
     "Amazon.de: Günstige Preise für Elektronik & Foto, Filme, Musik, Bücher, Games, Spielzeug & mehr",
-    "Amazon.fr : livres, DVD, jeux vidéo, musique, high-tech, informatique, jouets, vêtements, chaussures, sport, bricolage, maison, beauté, puériculture, épicerie et plus encore !"
+    "Amazon.fr : livres, DVD, jeux vidéo, musique, high-tech, informatique, jouets, vêtements, chaussures, sport, bricolage, maison, beauté, puériculture, épicerie et plus encore !",
 ]
 SHOPING_CART_TITLES = [
     "Amazon.com Shopping Cart",
@@ -43,7 +43,7 @@ SHOPING_CART_TITLES = [
     "Amazon.de Basket",
     "Amazon.de Einkaufswagen",
     "Cesta de compra Amazon.es",
-    "Amazon.fr Panier"
+    "Amazon.fr Panier",
 ]
 CHECKOUT_TITLES = [
     "Amazon.com Checkout",
@@ -55,21 +55,21 @@ CHECKOUT_TITLES = [
     "Place Your Order - Amazon.com Checkout",
     "Place Your Order - Amazon.com",
     "Tramitar pedido en Amazon.es",
-    "Processus de paiement Amazon.com"
+    "Processus de paiement Amazon.com",
 ]
 ORDER_COMPLETE_TITLES = [
-    "Amazon.com Thanks You", 
+    "Amazon.com Thanks You",
     "Amazon.ca Thanks You",
-    "Thank you", 
-    "Amazon.fr Merci", 
-    "Merci"
+    "Thank you",
+    "Amazon.fr Merci",
+    "Merci",
 ]
 ADD_TO_CART_TITLES = [
     "Amazon.com: Please Confirm Your Action",
     "Amazon.de: Bitte bestätigen Sie Ihre Aktion",
     "Amazon.de: Please Confirm Your Action",
     "Amazon.es: confirma tu acción",
-    "Amazon.com : Veuillez confirmer votre action"  # Careful, required non-breaking space after .com (&nbsp)
+    "Amazon.com : Veuillez confirmer votre action",  # Careful, required non-breaking space after .com (&nbsp)
 ]
 
 

--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -28,6 +28,7 @@ SIGN_IN_TITLES = ["Amazon Sign In", "Amazon Sign-In", "Amazon Anmelden"]
 CAPTCHA_PAGE_TITLES = ["Robot Check"]
 HOME_PAGE_TITLES = [
     "Amazon.com: Online Shopping for Electronics, Apparel, Computers, Books, DVDs & more",
+    "Amazon.ca: Low Prices - Fast Shipping - Millions of Items",
     "Amazon.co.uk: Low Prices in Electronics, Books, Sports Equipment & more",
     "Amazon.de: Low Prices in Electronics, Books, Sports Equipment & more",
     "Amazon.de: Günstige Preise für Elektronik & Foto, Filme, Musik, Bücher, Games, Spielzeug & mehr",
@@ -37,6 +38,7 @@ HOME_PAGE_TITLES = [
 ]
 SHOPING_CART_TITLES = [
     "Amazon.com Shopping Cart",
+    "Amazon.ca Shopping Cart",
     "Amazon.co.uk Shopping Basket",
     "Amazon.de Basket",
     "Amazon.de Einkaufswagen",
@@ -45,6 +47,7 @@ SHOPING_CART_TITLES = [
 ]
 CHECKOUT_TITLES = [
     "Amazon.com Checkout",
+    "Place Your Order - Amazon.ca Checkout",
     "Place Your Order - Amazon.co.uk Checkout",
     "Amazon.de Checkout",
     "Place Your Order - Amazon.de Checkout",
@@ -54,7 +57,13 @@ CHECKOUT_TITLES = [
     "Tramitar pedido en Amazon.es",
     "Processus de paiement Amazon.com"
 ]
-ORDER_COMPLETE_TITLES = ["Amazon.com Thanks You", "Thank you", "Amazon.fr Merci", "Merci"]
+ORDER_COMPLETE_TITLES = [
+    "Amazon.com Thanks You", 
+    "Amazon.ca Thanks You",
+    "Thank you", 
+    "Amazon.fr Merci", 
+    "Merci"
+]
 ADD_TO_CART_TITLES = [
     "Amazon.com: Please Confirm Your Action",
     "Amazon.de: Bitte bestätigen Sie Ihre Aktion",


### PR DESCRIPTION
The `ADD_TO_CART` title for amazon.ca appears to be the same as it is for amazon.com - hence no additional string added there. See https://www.amazon.ca/gp/aws/cart/add.html?ASIN.1=B085M66LH1&Quantity.1=1