### PR TITLE
Add timestamps to notification-test command

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -1,8 +1,9 @@
 import click
 
+from datetime import datetime
 from cli.utils import QuestionaryOption
 from functools import wraps
-from notifications.notifications import NotificationHandler
+from notifications.notifications import NotificationHandler, TIME_FORMAT
 from signal import signal, SIGINT
 from stores.amazon import Amazon
 from stores.bestbuy import BestBuyHandler
@@ -95,8 +96,9 @@ def evga(test, headless):
 @click.command()
 def test_notifications():
     enabled_handlers = ", ".join(notification_handler.get_enabled_handlers())
+    time = datetime.now().strftime(TIME_FORMAT)
     notification_handler.send_notification(
-        f"🤖 Beep boop. This is a test notification from Nvidia bot."
+        f"🤖 Beep boop. This is a test notification from Nvidia bot. Sent {time}."
     )
     log.info(f"A notification was sent to the following handlers: {enabled_handlers}")
 

--- a/notifications/notifications.py
+++ b/notifications/notifications.py
@@ -9,6 +9,8 @@ from notifications.providers.telegram import TelegramHandler
 from notifications.providers.twilio import TwilioHandler
 from utils.logger import log
 
+TIME_FORMAT = "%Y-%m-%d @ %H:%M:%S"
+
 
 class NotificationHandler:
     def __init__(self):


### PR DESCRIPTION
When testing/debugging notification sending it is helpful to know when the notification was sent. This helps surface delays from when notifications are sent to when they are received. 

It may also be a useful to add these timestamps to the stock notifications in the future also, but I've not included that in this PR.