### PR TITLE
Add extra Amazon UK checkout page title

### DIFF
--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -47,6 +47,7 @@ SHOPING_CART_TITLES = [
 ]
 CHECKOUT_TITLES = [
     "Amazon.com Checkout",
+    "Amazon.co.uk Checkout",
     "Place Your Order - Amazon.ca Checkout",
     "Place Your Order - Amazon.co.uk Checkout",
     "Amazon.de Checkout",


### PR DESCRIPTION
Sometimes the checkout page on Amazon UK has a different page title. This PR adds that page title to the list of `SHOPING_CART_TITLES`