### PR TITLE
Update amazoncaptcha version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,5 +23,5 @@ prompt_toolkit = "*"
 aiohttp = "*"
 pyobjc = {version = "*", sys_platform = "== 'darwin'"}
 async-timeout = "*"
-amazoncaptcha = "==0.3.10"
+amazoncaptcha = "==0.4.4"
 browser-cookie3 = "*"

--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -184,7 +184,7 @@ class Amazon:
             return
         try:
             log.info("Stuck on a captcha... Lets try to solve it.")
-            captcha = AmazonCaptcha.from_webdriver(self.driver)
+            captcha = AmazonCaptcha.fromdriver(self.driver)
             solution = captcha.solve()
             log.info(f"The solution is: {solution}")
             if solution == "Not solved":


### PR DESCRIPTION
+ Update amazoncaptcha library version to 0.4.4
+ Replace deprecated class method `from_webdriver` with `fromdriver`

This doesn't change the behavior of the method `solve` in terms of solving a captcha image, just a quick pre-fix before discussing issue #231 