### PR TITLE
Specify rquired Python version in Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -3,6 +3,9 @@ name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 
+[requires]
+python_version = "3.8"
+
 [dev-packages]
 pyinstaller = "*"
 


### PR DESCRIPTION
We've had a lot of reports of people having issues since Python 3.9 was released. 

As a stopgap measure I've updated the Pipfile configuration so that a known-good Python version is installed when users prepare the environment.