### PR TITLE
Add a captcha link to the logs, if it was "Not solved"

### DIFF
--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -188,7 +188,7 @@ class Amazon:
             solution = captcha.solve()
             log.info(f"The solution is: {solution}")
             if solution == "Not solved":
-                log.info(f"Failed to solve, lets reload and get a new captcha.")
+                log.info(f"Failed to solve {captcha.image_link}, lets reload and get a new captcha.")
                 self.driver.refresh()
                 time.sleep(5)
                 self.get_captcha_help()


### PR DESCRIPTION
Resolves #231

Arguments to support this type of logs instead of a separated file:
+ I've noticed that mostly it is convenient for users to just post an image where we can see a constant "Not solved" result. If now this image will also contain the link of an unsolved image, it will be possible to apply next logic: 
    + if the link we see is definitely not a captcha image, maybe the bot was at incorrect page, therefore it will be easier to find the source, or at least, it will give more information
    + if the link is actually a captcha image, I can cross-check the problem with the amazoncaptcha library to also provide more information.
+ the main problem at this moment is that, actually, when someone posts an image with a constant "Not solved" without providing any more information, it is almost impossible to identify why that happened. This fix will at least point a direction.