### PR TITLE
Change message wording/ordering for clarity

### DIFF
--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -193,12 +193,12 @@ class Amazon:
                 self.get_captcha_help()
             else:
                 self.driver.save_screenshot("screenshot.png")
-                self.notification_handler.send_notification(
-                    f"Solving Captcha: {solution}", True
-                )
                 self.driver.find_element_by_xpath(
                     '//*[@id="captchacharacters"]'
                 ).send_keys(solution + Keys.RETURN)
+                self.notification_handler.send_notification(
+                    f"Solved captcha with solution: {solution}", True
+                )
         except Exception as e:
             log.debug(e)
             log.info("Error trying to solve captcha. Refresh and retry.")


### PR DESCRIPTION
Users have been confused in the Discord server over whether the captcha has been solved after this notification has been sent. I changed the wording to be more obvious, and send _after_ the captcha has been solved.