### PR TITLE
Parse configuration before launching browser 

### DIFF
--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -8,7 +8,10 @@ from amazoncaptcha import AmazonCaptcha
 from chromedriver_py import binary_path  # this will get you the path variable
 from furl import furl
 from selenium import webdriver
-from selenium.common.exceptions import NoSuchElementException, SessionNotCreatedException
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    SessionNotCreatedException,
+)
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -104,15 +107,7 @@ class Amazon:
         self.notification_handler = notification_handler
         self.asin_list = []
         self.reserve = []
-        if headless:
-            enable_headless()
-        options.add_argument(f"user-data-dir=.profile-amz")
-        try:
-            self.driver = webdriver.Chrome(executable_path=binary_path, options=options)
-            self.wait = WebDriverWait(self.driver, 10)
-        except Exception as e:
-            log.error(e)
-            exit(1)
+
         if path.exists(AUTOBUY_CONFIG_PATH):
             with open(AUTOBUY_CONFIG_PATH) as json_file:
                 try:
@@ -124,8 +119,8 @@ class Amazon:
                         "amazon_website", "smile.amazon.com"
                     )
                     for x in range(self.asin_groups):
-                        self.asin_list.append(config[f"asin_list_{x+1}"])
-                        self.reserve.append(float(config[f"reserve_{x+1}"]))
+                        self.asin_list.append(config[f"asin_list_{x + 1}"])
+                        self.reserve.append(float(config[f"reserve_{x + 1}"]))
                     # assert isinstance(self.asin_list, list)
                 except Exception:
                     log.error(
@@ -137,6 +132,16 @@ class Amazon:
                 "No config file found, see here on how to fix this: https://github.com/Hari-Nagarajan/nvidia-bot/wiki/Usage#json-configuration"
             )
             exit(0)
+
+        if headless:
+            enable_headless()
+        options.add_argument(f"user-data-dir=.profile-amz")
+        try:
+            self.driver = webdriver.Chrome(executable_path=binary_path, options=options)
+            self.wait = WebDriverWait(self.driver, 10)
+        except Exception as e:
+            log.error(e)
+            exit(1)
 
         for key in AMAZON_URLS.keys():
             AMAZON_URLS[key] = AMAZON_URLS[key].format(domain=self.amazon_website)
@@ -225,7 +230,7 @@ class Amazon:
                             break
             if self.asin_list:  # keep bot going if additional ASINs left
                 checkout_success = False
-                #log.info("Additional lists remaining, bot will continue")
+                # log.info("Additional lists remaining, bot will continue")
 
     def check_stock(self, asin, reserve):
         f = furl(AMAZON_URLS["OFFER_URL"] + asin + "/ref=olp_f_new?f_new=true")
@@ -335,7 +340,7 @@ class Amazon:
                     )
                     self.asin_list[i] = good_asin_list
                 else:
-                    log.error(f"No ASINs work in list {i+1}.")
+                    log.error(f"No ASINs work in list {i + 1}.")
                     self.asin_list[i] = self.asin_list[i][
                         0
                     ]  # just assign one asin to list, can't remove during execution


### PR DESCRIPTION
Attempt to prevent covering console errors and orphaning Chrome.

Formatting differences are due to using "black" to try to remain compatible with source repo workflow