### PR TITLE
Fix pipenv lock after release of Selenium 4

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 pyinstaller = "*"
 
 [packages]
-requests = "==2.24.0"
+requests = "*"
 click = "*"
 selenium = "*"
 chromedriver-py = "==94.0.4606.41"


### PR DESCRIPTION
The October 13th release of `selenium` v4 updates its minimum `requests` version to `>2.24.0`, causing the current Pipfile to be unlockable. Setting `requests = "*"` allows it to resolve to `2.25.1` and lock properly.

Looking back at the commit that changed `requests = "==2.24.0"`, it didn't seem to be for any particular reason.

We could also pin `selenium` to v3, however it seems to be working fine for me on v4.